### PR TITLE
Tooltip + Council Districts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>North Texas Evictions Project</title>
+    <link rel="stylesheet" href="https://use.typekit.net/vjl2zvw.css"></link>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -12,6 +12,8 @@ const App = (props) => {
 
   // update route on state changes
   useEffect(() => {
+    // do not set undefined route
+    if (route.indexOf("undefined") > -1) return null;
     window.history && window.history.replaceState(null, null, "?" + route);
   }, [route]);
 

--- a/src/App/components/Header.js
+++ b/src/App/components/Header.js
@@ -7,7 +7,7 @@ import Branding from "./Branding";
 
 const Header = ({ children, ...props }) => {
   return (
-    <HypHeader {...props}>
+    <HypHeader elevation={1} {...props}>
       <Box
         px={[2, 3]}
         display="flex"

--- a/src/Dashboard/Dashboard.js
+++ b/src/Dashboard/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { Box } from "@material-ui/core";
 import useLanguageStore from "../Language/useLanguageStore";
 import useSetDashboardState from "./hooks/useSetDashboardState";
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import Panel from "../Panel/Panel";
 import { withStyles } from "@material-ui/styles";
 import { Tooltip } from "../Tooltip";
+import useDashboardStore from "./hooks/useDashboardStore";
 
 // Create a client
 const queryClient = new QueryClient();
@@ -53,9 +54,18 @@ const Dashboard = ({
     setLanguage(lang, langDict);
   }, [lang, langDict, setLanguage]);
 
+  // track mouse coords for tooltip
+  const setHoverCoords = useDashboardStore((state) => state.setHoverCoords);
+  const handleMouseMove = useCallback(
+    (e) => {
+      setHoverCoords([e.clientX, e.clientY]);
+    },
+    [setHoverCoords]
+  );
+
   return (
     <QueryClientProvider client={queryClient}>
-      <Wrapper>
+      <Wrapper onMouseMove={handleMouseMove}>
         <Box position="relative" style={{ flex: 1 }}>
           <Legend />
           <Map />
@@ -87,6 +97,7 @@ Dashboard.defaultProps = {
       METRIC_MPV: "Median Property Value",
       METRIC_PRH: "% Renter Homes",
       METRIC_RB: "Rent Burden",
+      METRIC_TFA: "Total Filing Amount",
       REGION_COUNTIES: "Counties",
       REGION_TRACTS: "Census Tracts",
       REGION_ZIPS: "ZIP Codes",
@@ -148,6 +159,7 @@ Dashboard.defaultProps = {
     { id: "ef", type: "bubble", format: "integer" },
     { id: "efr", type: "bubble", format: "integer" },
     { id: "mfa", type: "bubble", format: "currency" },
+    { id: "tfa", type: "secondary", format: "currency" },
     { id: "cpr", type: "choropleth", format: "percent" },
     { id: "mgr", type: "choropleth", format: "currency" },
     { id: "mhi", type: "choropleth", format: "currency" },

--- a/src/Dashboard/Dashboard.js
+++ b/src/Dashboard/Dashboard.js
@@ -101,7 +101,8 @@ Dashboard.defaultProps = {
       REGION_COUNTIES: "Counties",
       REGION_TRACTS: "Census Tracts",
       REGION_ZIPS: "ZIP Codes",
-      REGION_PLACES: "Cities",
+      REGION_CITIES: "Cities",
+      REGION_DISTRICTS: "Council Districts",
       LEGEND_SUMMARY: "between {{start}} and {{end}}",
       BUTTON_CHANGE_OPTIONS: "Change Data Options",
       SELECT_CHOROPLETH: "Demographic Metric",
@@ -131,7 +132,7 @@ Dashboard.defaultProps = {
         "https://raw.githubusercontent.com/childpovertyactionlab/cpal-evictions/main/bubble/NTEP_bubble_county.geojson",
     },
     {
-      id: "places",
+      id: "cities",
       type: "geojson",
       choropleth:
         "https://raw.githubusercontent.com/childpovertyactionlab/cpal-evictions/main/demo/NTEP_demographics_place.geojson",
@@ -145,6 +146,14 @@ Dashboard.defaultProps = {
         "https://raw.githubusercontent.com/childpovertyactionlab/cpal-evictions/main/demo/NTEP_demographics_zip.geojson",
       bubble:
         "https://raw.githubusercontent.com/childpovertyactionlab/cpal-evictions/main/bubble/NTEP_bubble_zip.geojson",
+    },
+    {
+      id: "districts",
+      type: "geojson",
+      choropleth:
+        "https://raw.githubusercontent.com/childpovertyactionlab/cpal-evictions/main/demo/NTEP_demographics_council.geojson",
+      bubble:
+        "https://raw.githubusercontent.com/childpovertyactionlab/cpal-evictions/main/bubble/NTEP_bubble_council.geojson",
     },
     {
       id: "tracts",

--- a/src/Dashboard/constants.js
+++ b/src/Dashboard/constants.js
@@ -7,3 +7,6 @@ export const DEFAULT_BUBBLE_COLOR = "#e98816";
 
 export const EVICTION_DATA_ENDPOINT =
   "https://cnvdr1v7ki.execute-api.us-east-1.amazonaws.com";
+
+// metrics to show in the tooltip (TODO: move to config props)
+export const TOOLTIP_METRICS = ["ef", "efr", "mfa", "tfa"];

--- a/src/Dashboard/hooks/useDashboardStore.js
+++ b/src/Dashboard/hooks/useDashboardStore.js
@@ -22,6 +22,8 @@ const useDashboardStore = create((set) => ({
   setFilters: (filters) => set({ filters }),
   activePanel: null,
   setActivePanel: (activePanel) => set({ activePanel }),
+  hoverCoords: [0, 0],
+  setHoverCoords: (hoverCoords) => set({ hoverCoords }),
 }));
 
 export default useDashboardStore;

--- a/src/Dashboard/hooks/useFormatter.js
+++ b/src/Dashboard/hooks/useFormatter.js
@@ -1,18 +1,26 @@
-import { format } from "d3-format";
+import { format as d3format } from "d3-format";
 import useDashboardStore from "./useDashboardStore";
 
 /**
- * Returns a function for formatting values for the current metric
- * @param {*} metric
+ * Returns a formatter function for the given format string
+ * and also formats invalid values
+ */
+const format = (formatString) => {
+  const formatter = d3format(formatString);
+  return (value) => {
+    if (!Number.isFinite(value)) return "--";
+    return formatter(value);
+  };
+};
+
+/**
+ * Returns a formatter function for the given format string.
+ * @param {*} format
+ * @param {*} options
  * @returns
  */
-export default function useFormatter(metric, options = { short: false }) {
-  const metrics = useDashboardStore((state) => state.metrics);
-  const metricConfig = metrics.find((m) => m.id === metric);
-
-  if (!metrics || !metricConfig) return format(".2f");
-
-  switch (metricConfig.format) {
+export const getFormatter = (type, options = { short: false }) => {
+  switch (type) {
     case "percent":
       return format(".1%");
     case "number":
@@ -24,4 +32,27 @@ export default function useFormatter(metric, options = { short: false }) {
     default:
       return format(".2s");
   }
+};
+
+/**
+ * Returns a function for formatting values for the current metric
+ * @param {*} metric
+ * @returns
+ */
+export default function useFormatter(metric, options = { short: false }) {
+  const metrics = useDashboardStore((state) => state.metrics);
+  const metricConfig = metrics.find((m) => m.id === metric);
+  if (!metrics || !metricConfig) return format(".2f");
+  return getFormatter(metricConfig.format, options);
+}
+
+/** Returns formatters for the given metrics */
+export function useFormatters(metrics, options) {
+  const metricConfigs = useDashboardStore((state) => state.metrics);
+  const formatters = metrics.map((metric) => {
+    const metricConfig = metricConfigs.find((m) => m.id === metric);
+    if (!metrics || !metricConfig) return format(".2f");
+    return getFormatter(metricConfig.format, options);
+  });
+  return formatters;
 }

--- a/src/Dashboard/hooks/useSetDashboardState.js
+++ b/src/Dashboard/hooks/useSetDashboardState.js
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import shallow from "zustand/shallow";
 import useDashboardStore from "./useDashboardStore";
 
 /**
@@ -22,15 +23,18 @@ export default function useSetDashboardState({
     setActiveRegion,
     setDateRange,
     setActiveDateRange,
-  ] = useDashboardStore((state) => [
-    state.setMetrics,
-    state.setRegions,
-    state.setActiveBubble,
-    state.setActiveChoropleth,
-    state.setActiveRegion,
-    state.setDateRange,
-    state.setActiveDateRange,
-  ]);
+  ] = useDashboardStore(
+    (state) => [
+      state.setMetrics,
+      state.setRegions,
+      state.setActiveBubble,
+      state.setActiveChoropleth,
+      state.setActiveRegion,
+      state.setDateRange,
+      state.setActiveDateRange,
+    ],
+    shallow
+  );
 
   // update active bubble on changes
   useEffect(() => {

--- a/src/Data/useBubblesData.js
+++ b/src/Data/useBubblesData.js
@@ -2,7 +2,11 @@ import { useQuery } from "react-query";
 import { EVICTION_DATA_ENDPOINT } from "../Dashboard/constants";
 import useDashboardContext from "../Dashboard/hooks/useDashboardContext";
 import useDashboardRegion from "../Dashboard/hooks/useDashboardRegion";
-import { addDataToGeojson, extractExtentsFromGeojson } from "./utils";
+import {
+  addDataToGeojson,
+  addFeatureIds,
+  extractExtentsFromGeojson,
+} from "./utils";
 
 /**
  * Fetches bubble GeoJSON and returns and object
@@ -20,9 +24,9 @@ const fetchBubbleGeojson = (url) => {
 const fetchBubbleData = ({ region, start, end }) => {
   if (!region) return Promise.reject("no region provided for bubble data");
   const paramString = new URLSearchParams({ region, start, end }).toString();
-  return fetch(
-    `${EVICTION_DATA_ENDPOINT}/summary?${paramString}`
-  ).then((response) => response.json());
+  return fetch(`${EVICTION_DATA_ENDPOINT}/summary?${paramString}`).then(
+    (response) => response.json()
+  );
 };
 
 /**
@@ -57,7 +61,7 @@ const fetchAllBubbleData = (params, geojsonUrl) => {
   ]).then(([geojson, evictionData]) => {
     if (!geojson || !evictionData) return null;
     const mergedGeojson = addFilingRatesToGeojson(
-      addDataToGeojson(geojson, evictionData.result)
+      addDataToGeojson(addFeatureIds(geojson), evictionData.result)
     );
     return {
       extents: extractExtentsFromGeojson(mergedGeojson),

--- a/src/Data/useSummaryData.js
+++ b/src/Data/useSummaryData.js
@@ -6,6 +6,9 @@ import useDashboardStore from "../Dashboard/hooks/useDashboardStore";
  * Fetches eviction filings data from the API
  */
 const fetchSummary = ({ start, end }) => {
+  if (!start || !end) {
+    return Promise.reject("start and end dates are required");
+  }
   const paramString = new URLSearchParams({ start, end }).toString();
   return fetch(`${EVICTION_DATA_ENDPOINT}/summary?${paramString}`)
     .then((response) => response.json())

--- a/src/Data/utils.js
+++ b/src/Data/utils.js
@@ -6,14 +6,20 @@ import { quantile } from "d3-array";
 export const addFeatureIds = (geojson) => {
   return {
     ...geojson,
-    features: geojson.features.map((feature, i) =>
-      feature.id
-        ? feature
-        : {
-            id: feature.properties.id ? Number(feature.properties.id) : i + 1,
-            ...feature,
-          }
-    ),
+    features: geojson.features.map((feature, i) => {
+      // feature ID should only contain numbers
+      const newFeatureId = feature.properties.id
+        ? feature.properties.id.replace(/\D/g, "")
+        : i + 1;
+      return {
+        ...feature,
+        id: newFeatureId,
+        properties: {
+          ...feature.properties,
+          id: newFeatureId,
+        },
+      };
+    }),
   };
 };
 

--- a/src/Data/utils.js
+++ b/src/Data/utils.js
@@ -39,7 +39,6 @@ export const extractExtentsFromGeojson = (geojson, options = {}) => {
       features.map((f) => f.properties[keys[i]]).filter(Boolean), // all values
     ];
   }
-  console.log(extents);
   return extents;
 };
 

--- a/src/Legend/Legend.js
+++ b/src/Legend/Legend.js
@@ -17,6 +17,7 @@ import BubbleLegend from "./components/BubbleLegend";
 import ChoroplethLegend from "./components/ChoroplethLegend";
 import { ArrowDropUp, Close } from "@material-ui/icons";
 import useMeasure from "react-use-measure";
+import { Stack } from "@hyperobjekt/material-ui-website";
 
 const styles = (theme) => ({
   root: {
@@ -26,37 +27,11 @@ const styles = (theme) => ({
     padding: theme.spacing(2, 0, 0),
     zIndex: 10,
     width: 320,
-    boxShadow: "0px 8px 20px rgba(0, 0, 0, 0.05)",
     [theme.breakpoints.down("sm")]: {
       top: "auto",
       bottom: 0,
       right: 0,
       width: "100vw",
-    },
-  },
-  eyebrow: {
-    color: theme.props.text.secondary,
-    textTransform: "uppercase",
-    fontSize: theme.typography.pxToRem(12),
-    lineHeight: theme.typography.pxToRem(16),
-    letterSpacing: "0.09em",
-    margin: theme.spacing(0, 0, 2),
-  },
-  region: {
-    color: theme.props.text.primary,
-    fontSize: theme.typography.pxToRem(16),
-    lineHeight: theme.typography.pxToRem(16),
-    margin: theme.spacing(0, 0, 1),
-    fontWeight: 500,
-  },
-  body: {
-    color: theme.props.text.secondary,
-    fontSize: theme.typography.pxToRem(14),
-    lineHeight: theme.typography.pxToRem(19),
-    margin: 0,
-    [theme.breakpoints.down("sm")]: {
-      // TODO: abstract the mobile toggle btn width to a constant
-      marginRight: "63px",
     },
   },
   box: {
@@ -65,6 +40,9 @@ const styles = (theme) => ({
     "&:first-child": {
       borderTop: 0,
       paddingTop: 0,
+    },
+    "& strong": {
+      fontWeight: 500,
     },
   },
   toggleContainer: {
@@ -171,30 +149,41 @@ const Legend = ({ classes, ...props }) => {
   });
 
   return (
-    <AnimatedPaper style={style} className={classes.root} {...props}>
-      <Box className={classes.box}>
-        <Typography className={classes.eyebrow}>{legendTitle}</Typography>
-        <Typography className={classes.region}>{regionName}</Typography>
-        <Typography className={classes.body}>
+    <AnimatedPaper
+      style={style}
+      elevation={2}
+      className={classes.root}
+      {...props}
+    >
+      <Stack direction="vertical" between="sm" className={classes.box}>
+        <Typography component="h2" variant="overline" color="textSecondary">
+          {legendTitle}
+        </Typography>
+        <Typography variant="h2" component="h3">
+          {regionName}
+        </Typography>
+        <Typography variant="body1" color="textSecondary">
           <strong>{bubbleName}</strong>
           <span> and </span>
           <strong>{choroplethName}</strong>
           <span> {summaryText}</span>
         </Typography>
-      </Box>
+      </Stack>
       <animated.div className={classes.toggleContainer}>
         <div ref={toggleRef}>
           <Box className={classes.box}>
             <PanelToggle />
           </Box>
           <Box className={classes.box}>
-            <Typography className={classes.eyebrow}>
+            <Typography variant="overline" color="textSecondary">
               {summaryHeading}
             </Typography>
             <Summary />
           </Box>
           <Box className={classes.box}>
-            <Typography className={classes.eyebrow}>{legendHeading}</Typography>
+            <Typography variant="overline" color="textSecondary">
+              {legendHeading}
+            </Typography>
             <BubbleLegend title={bubbleName} />
             <ChoroplethLegend title={choroplethName} />
           </Box>

--- a/src/Legend/components/ChoroplethLegend.js
+++ b/src/Legend/components/ChoroplethLegend.js
@@ -34,7 +34,7 @@ const ChoroplethLegend = (props) => {
   const tooltipData = useTooltipData();
   const { activeChoropleth } = useDashboardContext();
   const extents = useDataExtents();
-  const width = 200;
+  const width = 188;
   const activeValue = tooltipData && tooltipData[activeChoropleth];
   const margin = { left: 24, right: 16, top: 0, bottom: 2 };
   const formatter = useFormatter(activeChoropleth, {

--- a/src/Legend/components/LegendRow.js
+++ b/src/Legend/components/LegendRow.js
@@ -9,17 +9,14 @@ const styles = (theme) => ({
     alignItems: "center",
     margin: theme.spacing(2, 0, 0),
   },
-  title: {
-    color: theme.props.text.secondary,
-    fontSize: theme.typography.pxToRem(12),
-    lineHeight: theme.typography.pxToRem(16),
-  },
 });
 
 const LegendRow = ({ classes, className, title, children, ...props }) => {
   return (
     <Box className={clsx(classes.root, className)} {...props}>
-      <Typography className={classes.title}>{title}</Typography>
+      <Typography variant="caption" color="textSecondary">
+        {title}
+      </Typography>
       {children}
     </Box>
   );

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -1,6 +1,51 @@
-import React from "react";
-import { withStyles } from "@material-ui/core";
+import React, { useRef } from "react";
+import { Box, Divider, Paper, Typography, withStyles } from "@material-ui/core";
 import { useTooltipData } from ".";
+import clsx from "clsx";
+import { TOOLTIP_METRICS } from "../Dashboard/constants";
+import { useLang } from "../Language";
+import { useFormatters } from "../Dashboard/hooks/useFormatter";
+import { Stack } from "@hyperobjekt/material-ui-website";
+import useDashboardStore from "../Dashboard/hooks/useDashboardStore";
+import shallow from "zustand/shallow";
+import { animated, useSpring } from "react-spring";
+import { scaleLinear } from "@visx/scale";
+
+/**
+ * Helper component for rendering tooltip stats
+ */
+const Stat = ({
+  label,
+  value,
+  valueColor = "textPrimary",
+  labelColor = "textSecondary",
+  ...props
+}) => {
+  return (
+    <Box
+      display="flex"
+      justifyContent="space-between"
+      alignItems="center"
+      {...props}
+    >
+      <Typography
+        style={{ maxWidth: "12em" }}
+        component="span"
+        variant="caption"
+        color={labelColor}
+      >
+        {label}
+      </Typography>
+      <Typography component="span" variant="h2" color={valueColor}>
+        {value}
+      </Typography>
+    </Box>
+  );
+};
+
+// tooltip dimensions (height is an estimate for offsets)
+const TOOLTIP_WIDTH = 240;
+const TOOLTIP_HEIGHT = 320;
 
 const styles = (theme) => ({
   root: {
@@ -8,16 +53,128 @@ const styles = (theme) => ({
     top: 0,
     left: 0,
     zIndex: 101,
+    width: TOOLTIP_WIDTH,
+    pointerEvents: "none",
+  },
+  label: {
+    maxWidth: "8em",
+    paddingRight: theme.spacing(2),
   },
 });
 
+/** Returns the title and subtitle values based on the data */
+const getTooltipTitle = (data) => {
+  if (!data || !data.name) return ["Unavailable", ""];
+  const [name, parent] = data.name.split(",");
+  return [name, parent || "Texas"];
+};
+
+/** Returns the color to use for the value (bubble + choropleth metrics are highlighted) */
+const getValueColor = (metric, activeBubble, activeChoropleth) => {
+  if (metric === activeBubble) return "primary";
+  if (metric === activeChoropleth) return "secondary";
+  return "textPrimary";
+};
+
+// create animated version of Paper for react-spring
+const AnimatedPaper = animated(Paper);
+
+// create a scale for offsetting the tooltip so it doesn't go off the screen
+const offsetScale = scaleLinear()
+  .domain([0, window.innerWidth])
+  .range([0, -1 * TOOLTIP_WIDTH]);
+
+/**
+ * Returns a vertical offset for the tooltip if it is going to go off screen
+ * TODO: tooltip height is set to 320. ideally, this should be dynamic
+ * @param {*} y
+ * @returns
+ */
+const getVerticalOffset = (y) => {
+  if (y + TOOLTIP_HEIGHT >= window.innerHeight) return -1 * TOOLTIP_HEIGHT;
+  return 0;
+};
+
 const Tooltip = ({ classes, ...props }) => {
+  // retrieve required data for rendering the tooltip
   const data = useTooltipData();
-  return data ? (
-    <pre className={classes.root} {...props}>
-      {JSON.stringify(data, null, 2)}
-    </pre>
-  ) : null;
+  const hoverCoords = useDashboardStore((state) => state.hoverCoords);
+  const [activeBubble, activeChoropleth] = useDashboardStore(
+    (state) => [state.activeBubble, state.activeChoropleth],
+    shallow
+  );
+
+  // animate position and opacity
+  const style = useSpring({
+    x: (hoverCoords[0] || 0) + offsetScale(hoverCoords[0]),
+    y: (hoverCoords[1] || 0) + getVerticalOffset(hoverCoords[1]),
+    opacity: data ? 1 : 0,
+  });
+
+  // first 2 metrics are bubble / choropleth, followed by any additional metrics
+  const metricIds = [
+    activeBubble,
+    activeChoropleth,
+    ...TOOLTIP_METRICS.filter(
+      (id) => id !== activeBubble && id !== activeChoropleth
+    ),
+  ];
+
+  // get labels for metrics
+  const metricKeys = metricIds.map((m) => `METRIC_${m}`);
+  const rowLabels = useLang(metricKeys);
+
+  // get formatters for metrics
+  const rowFormatters = useFormatters(metricIds);
+
+  // keep a ref to the data so we can gracefully fade out tooltip
+  const dataRef = useRef(null);
+  if (data) dataRef.current = data;
+
+  // don't render anything if no tooltip data has been set yet
+  if (!dataRef.current) return null;
+
+  // pull the title and data for the tooltip
+  const [name, parent] = getTooltipTitle(dataRef.current);
+  const rowData = metricIds.map((m, i) => rowFormatters[i](dataRef.current[m]));
+
+  return (
+    <AnimatedPaper
+      style={style}
+      elevation={3}
+      className={clsx(classes.root)}
+      {...props}
+    >
+      <Box p={2} pb={1.5}>
+        <Typography variant="h2">{name}</Typography>
+        {parent && (
+          <Typography component="span" variant="caption" color="textSecondary">
+            {parent}
+          </Typography>
+        )}
+      </Box>
+      <Divider />
+      {/* first, stack the bubble / choropleth metrics */}
+      <Stack direction="vertical" between="sm" around="md" alignItems="stretch">
+        {metricIds.slice(0, 2).map((id, i) => (
+          <Stat
+            key={i}
+            label={rowLabels[i]}
+            value={rowData[i]}
+            labelColor="textPrimary"
+            valueColor={getValueColor(id, activeBubble, activeChoropleth)}
+          />
+        ))}
+      </Stack>
+      <Divider />
+      {/* stack the remaining metrics, account for the index offset by adding 2 */}
+      <Stack direction="vertical" between="sm" around="md" alignItems="stretch">
+        {metricIds.slice(2).map((id, i) => (
+          <Stat key={i + 2} label={rowLabels[i + 2]} value={rowData[i + 2]} />
+        ))}
+      </Stack>
+    </AnimatedPaper>
+  );
 };
 
 export default withStyles(styles)(Tooltip);

--- a/src/Tooltip/useTooltipData.js
+++ b/src/Tooltip/useTooltipData.js
@@ -9,9 +9,10 @@ export default function useTooltipData() {
   const selectedFeature = useMapStore((state) => state.selectedFeature);
   const currentFeature = hoveredFeature || selectedFeature;
   const { data } = useBubblesData();
-  const bubbleFeature = data?.geojson?.features?.find(
-    (f) => f.properties?.id === currentFeature?.properties?.id
-  );
+  const bubbleFeature =
+    data?.geojson?.features?.find(
+      (f) => f.properties?.id === currentFeature?.properties?.id
+    ) || {};
   const tooltipData =
     currentFeature && bubbleFeature
       ? { ...currentFeature.properties, ...bubbleFeature.properties }

--- a/src/theme.js
+++ b/src/theme.js
@@ -10,8 +10,8 @@ const DARK_FOCUS_STATE = {
   boxShadow: `0 0 0 2px ${HEADER_BACKGROUND_COLOR}, 0 0 0 4px #649BA6`,
 };
 
-const fontFamily = `"ITC Franklin Gothic Std", "Roboto", "Helvetica", "Arial", sans-serif`;
-const altFontFamily = `"Degular", "Roboto", "Helvetica", "Arial", sans-serif`;
+const fontFamily = `"franklin-gothic-urw", "Roboto", "Helvetica", "Arial", sans-serif`;
+const altFontFamily = `"degular", "Roboto", "Helvetica", "Arial", sans-serif`;
 
 export default createTheme({
   palette: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -10,11 +10,18 @@ const DARK_FOCUS_STATE = {
   boxShadow: `0 0 0 2px ${HEADER_BACKGROUND_COLOR}, 0 0 0 4px #649BA6`,
 };
 
+const fontFamily = `"ITC Franklin Gothic Std", "Roboto", "Helvetica", "Arial", sans-serif`;
+const altFontFamily = `"Degular", "Roboto", "Helvetica", "Arial", sans-serif`;
+
 export default createTheme({
   palette: {
     primary: { main: "#EC7406" },
     secondary: {
-      main: "#8AB5BC",
+      main: "#008097",
+    },
+    text: {
+      primary: "rgba(68, 71, 67, 1)",
+      secondary: "rgba(114, 116, 109, 1)",
     },
     action: {
       hover: "rgba(236, 236, 213, 0.333)",
@@ -24,9 +31,83 @@ export default createTheme({
     },
     header: { text: HEADER_TEXT_COLOR, background: HEADER_BACKGROUND_COLOR },
   },
+  typography: {
+    fontFamily: fontFamily,
+    // for dialog headings
+    h1: {
+      fontFamily: altFontFamily,
+      fontSize: "1.5rem", // 24px
+      fontWeight: 600,
+      lineHeight: 1,
+    },
+    // for tooltip and panel headings
+    h2: {
+      fontFamily: fontFamily,
+      fontSize: "0.875rem", // 14px
+      fontWeight: 500,
+      lineHeight: 1,
+    },
+    body1: {
+      fontFamily: fontFamily,
+      fontSize: "0.875rem", // 14px
+      fontWeight: 400,
+      lineHeight: 1.42,
+    },
+    body2: {
+      fontFamily: fontFamily,
+      fontSize: "0.75rem", // 12px
+      fontWeight: 400,
+      lineHeight: 1.42,
+    },
+    // for labels
+    caption: {
+      fontFamily: fontFamily,
+      fontSize: "0.75rem", // 12px
+      fontWeight: 400,
+      lineHeight: 16 / 12,
+      letterSpacing: "0.02em", // 2%
+    },
+    // for section labels
+    overline: {
+      fontFamily: fontFamily,
+      fontSize: "0.75rem", // 12px
+      fontWeight: 500,
+      lineHeight: 16 / 12,
+      letterSpacing: "0.09em", // 9%
+      textTransform: "uppercase",
+    },
+    button: {
+      fontFamily: fontFamily,
+      fontSize: "0.75rem", // 12px
+      fontWeight: 500,
+      lineHeight: 16 / 12,
+      letterSpacing: "0.02em", // 2%
+    },
+  },
   shape: {
     borderRadius: 2,
   },
+  shadows: [
+    "none",
+    "0px 8px 20px rgba(0, 0, 0, 0.03)",
+    "0px 8px 20px rgba(0, 0, 0, 0.05)",
+    "0px 8px 20px rgba(0, 0, 0, 0.08)",
+    "0px 8px 22px rgba(0, 0, 0, 0.1)",
+    "0px 8px 24px rgba(0, 0, 0, 0.12)",
+    "0px 8px 26px rgba(0, 0, 0, 0.14)",
+    "0px 8px 28px rgba(0, 0, 0, 0.16)",
+    "0px 8px 30px rgba(0, 0, 0, 0.18)",
+    "0px 8px 32px rgba(0, 0, 0, 0.2)",
+    "0px 8px 34px rgba(0, 0, 0, 0.22)",
+    "0px 8px 36px rgba(0, 0, 0, 0.24)",
+    "0px 8px 38px rgba(0, 0, 0, 0.26)",
+    "0px 8px 40px rgba(0, 0, 0, 0.28)",
+    "0px 8px 42px rgba(0, 0, 0, 0.3)",
+    "0px 8px 44px rgba(0, 0, 0, 0.32)",
+    "0px 8px 46px rgba(0, 0, 0, 0.34)",
+    "0px 8px 48px rgba(0, 0, 0, 0.36)",
+    "0px 8px 50px rgba(0, 0, 0, 0.38)",
+  ],
   overrides: {
     HypHeader: {
       root: {


### PR DESCRIPTION
# Changes

- updates the tooltip component to render relevant data
- adds `hoverCoords` state to the dashboard store for tooltip positioning
- updates the theme with typography variants and update existing typography components to use the variants instead of custom classes
- updates theme with shadow variants and update existing components to use `elevation` prop
- update the `useFormatter` hook to also include `useFormatters`, which returns formatters for multiple metrics
- update the formatters to provide a more readable value when data is unavailable ("--" for now)
- add `shallow` comparator on `useSetDashboardState` hook to prevent performance issues
- adds council districts region