### PR TITLE
Short Formatters Fix

### DIFF
--- a/src/Dashboard/hooks/useFormatter.js
+++ b/src/Dashboard/hooks/useFormatter.js
@@ -14,6 +14,36 @@ const format = (formatString) => {
 };
 
 /**
+ * Returns short format for large integers (e.g. 1.2M)
+ * but keeps numbers below 1000 as normal integers (e.g. 531)
+ * @param {number} value
+ * @returns {string}
+ */
+const shortIntFormatter = (value) => {
+  const smallIntFormatter = format(",d");
+  const largeIntFormatter = format(".2~s");
+  if (value < 1000) {
+    return smallIntFormatter(value);
+  }
+  return largeIntFormatter(value);
+};
+
+/**
+ * Returns short format for large currencies (e.g. $1.2M)
+ * but keeps numbers below 1000 as integers (e.g. $531)
+ * @param {number} value
+ * @returns {string}
+ */
+const shortCurrencyFormatter = (value) => {
+  const smallFormatter = format("$,d");
+  const largeFormatter = format("$.2~s");
+  if (value < 1000) {
+    return smallFormatter(value);
+  }
+  return largeFormatter(value);
+};
+
+/**
  * Returns a formatter function for the given format string.
  * @param {*} format
  * @param {*} options
@@ -26,9 +56,9 @@ export const getFormatter = (type, options = { short: false }) => {
     case "number":
       return format(".2s");
     case "currency":
-      return options.short ? format("$.2~s") : format("$,.2f");
+      return options.short ? shortCurrencyFormatter : format("$,.2f");
     case "integer":
-      return options.short ? format(".2~s") : format(",d");
+      return options.short ? shortIntFormatter : format(",d");
     default:
       return format(".2s");
   }


### PR DESCRIPTION
implementation for #34

> note: the viewport will appear locked in the dev preview.  this will be fixed once #41 is merged in

# Changes

- create new short formatter functions for integers / currency that does not use short formats for values < 1000

before: 
![image](https://user-images.githubusercontent.com/21034/132546231-aeab50a6-2f25-4cdf-821f-7e47d3a8fd5e.png)

after:
![image](https://user-images.githubusercontent.com/21034/132546379-b5d720f5-d3e4-497c-bf6e-6a259a5162c2.png)
