### PR TITLE
region-based scaling for bubbles

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -83,33 +83,83 @@ App.defaultProps = {
     regions: [
       {
         id: "counties",
-        type: "geojson",
-        choropleth: GEOJSON_ROOT + "demo/NTEP_demographics_county.geojson",
-        bubble: GEOJSON_ROOT + "bubble/NTEP_bubble_county.geojson",
+        layers: [
+          {
+            id: "bubble",
+            type: "geojson",
+            source: GEOJSON_ROOT + "bubble/NTEP_bubble_county.geojson",
+            options: { scaleFactor: 5 },
+          },
+          {
+            id: "choropleth",
+            type: "geojson",
+            source: GEOJSON_ROOT + "demo/NTEP_demographics_county.geojson",
+          },
+        ],
       },
       {
         id: "cities",
-        type: "geojson",
-        choropleth: GEOJSON_ROOT + "demo/NTEP_demographics_place.geojson",
-        bubble: GEOJSON_ROOT + "bubble/NTEP_bubble_place.geojson",
+        layers: [
+          {
+            id: "bubble",
+            type: "geojson",
+            source: GEOJSON_ROOT + "bubble/NTEP_bubble_place.geojson",
+            options: { scaleFactor: 3 },
+          },
+          {
+            id: "choropleth",
+            type: "geojson",
+            source: GEOJSON_ROOT + "demo/NTEP_demographics_place.geojson",
+          },
+        ],
       },
       {
         id: "zips",
-        type: "geojson",
-        choropleth: GEOJSON_ROOT + "demo/NTEP_demographics_zip.geojson",
-        bubble: GEOJSON_ROOT + "bubble/NTEP_bubble_zip.geojson",
+        layers: [
+          {
+            id: "bubble",
+            type: "geojson",
+            source: GEOJSON_ROOT + "bubble/NTEP_bubble_zip.geojson",
+            options: { scaleFactor: 1.5 },
+          },
+          {
+            id: "choropleth",
+            type: "geojson",
+            source: GEOJSON_ROOT + "demo/NTEP_demographics_zip.geojson",
+          },
+        ],
       },
       {
         id: "districts",
-        type: "geojson",
-        choropleth: GEOJSON_ROOT + "demo/NTEP_demographics_council.geojson",
-        bubble: GEOJSON_ROOT + "bubble/NTEP_bubble_council.geojson",
+        layers: [
+          {
+            id: "bubble",
+            type: "geojson",
+            source: GEOJSON_ROOT + "bubble/NTEP_bubble_council.geojson",
+            options: { scaleFactor: 1.5 },
+          },
+          {
+            id: "choropleth",
+            type: "geojson",
+            source: GEOJSON_ROOT + "demo/NTEP_demographics_council.geojson",
+          },
+        ],
       },
       {
         id: "tracts",
-        type: "geojson",
-        choropleth: GEOJSON_ROOT + "demo/NTEP_demographics_tract.geojson",
-        bubble: GEOJSON_ROOT + "bubble/NTEP_bubble_tract.geojson",
+        layers: [
+          {
+            id: "bubble",
+            type: "geojson",
+            source: GEOJSON_ROOT + "bubble/NTEP_bubble_tract.geojson",
+            options: { scaleFactor: 1.1 },
+          },
+          {
+            id: "choropleth",
+            type: "geojson",
+            source: GEOJSON_ROOT + "demo/NTEP_demographics_tract.geojson",
+          },
+        ],
       },
     ],
     metrics: [
@@ -117,7 +167,6 @@ App.defaultProps = {
       { id: "efr", type: "bubble", format: "integer" },
       { id: "mfa", type: "bubble", format: "currency" },
       { id: "tfa", type: "secondary", format: "currency" },
-
       {
         id: "mgr",
         type: "choropleth",

--- a/src/Dashboard/constants.js
+++ b/src/Dashboard/constants.js
@@ -1,6 +1,3 @@
-// indentifiers for layers corresponding to each region
-export const REGION_LAYERS = [`choropleth`, `bubble`];
-
 // fallbacks for choropleth / bubbles that are secified in the config
 export const DEFAULT_CHOROPLETH_COLORS = ["#f0f7f9", "#a5d5db", "#008097"];
 export const DEFAULT_BUBBLE_COLOR = "#e98816";

--- a/src/Data/useBubblesData.js
+++ b/src/Data/useBubblesData.js
@@ -101,7 +101,8 @@ export default function useBubblesData() {
   const [precinct] = usePrecinctFilter();
 
   const region = regions.find((r) => r.id === activeRegion);
-  const geojsonUrl = region && region["bubble"];
+  const bubbleLayer = region?.layers?.find((l) => l.id === "bubble");
+  const geojsonUrl = bubbleLayer?.source;
   // update the data on changes
   return useQuery(["bubbles", activeRegion, start, end, precinct], () =>
     fetchAllBubbleData(

--- a/src/Data/useChoroplethData.js
+++ b/src/Data/useChoroplethData.js
@@ -26,7 +26,8 @@ const fetchChoroplethData = (url) => {
 function useRegionGeojson(regionId) {
   const regions = useDashboardStore((state) => state.regions);
   const region = regions.find((r) => r.id === regionId);
-  const geojsonUrl = region && region["choropleth"];
+  const choroplethLayer = region?.layers?.find((l) => l.id === "choropleth");
+  const geojsonUrl = choroplethLayer?.source;
   return useQuery(["choropleth", regionId], () =>
     fetchChoroplethData(geojsonUrl)
   );

--- a/src/Map/hooks/useMapLayers.js
+++ b/src/Map/hooks/useMapLayers.js
@@ -3,7 +3,6 @@ import { getColorInterpolator, getPositionScale } from "@hyperobjekt/legend";
 import {
   DEFAULT_BUBBLE_COLOR,
   DEFAULT_CHOROPLETH_COLORS,
-  REGION_LAYERS,
 } from "../../Dashboard/constants";
 import useDashboardStore from "../../Dashboard/hooks/useDashboardStore";
 import shallow from "zustand/shallow";
@@ -46,13 +45,16 @@ const getStepsFromChunks = (chunks) => {
 /**
  * Returns a mapboxgl style object for choropleth layers
  */
-const getChoroplethLayerStyle = ({
-  activeChoropleth = "pcw",
-  activeRegion = "tracts",
-  extents = [0, 1],
-  colors = DEFAULT_CHOROPLETH_COLORS,
-  scales,
-}) => {
+const getChoroplethLayerStyle = (
+  {
+    activeChoropleth = "pcw",
+    activeRegion = "tracts",
+    extents = [0, 1],
+    colors = DEFAULT_CHOROPLETH_COLORS,
+    scales,
+  },
+  options
+) => {
   const extent = extents && extents[activeChoropleth];
   const hasSteps = scales.chunks;
   const steps = hasSteps
@@ -107,13 +109,14 @@ const getChoroplethLayerStyle = ({
 /**
  * Returns a mapboxgl style object for bubble layers
  */
-const getBubbleLayerStyle = ({
-  activeRegion,
-  activeBubble = "pop",
-  extents,
-}) => {
+const getBubbleLayerStyle = (
+  { activeRegion, activeBubble = "pop", extents },
+  options
+) => {
   const extent = extents && extents[activeBubble];
   if (!extent) return [];
+  const scaleFactor = options?.scaleFactor || 1;
+  const adjustSizeFactor = (v) => v * scaleFactor;
   return [
     {
       id: `${activeRegion}-bubble`,
@@ -133,7 +136,10 @@ const getBubbleLayerStyle = ({
               "interpolate",
               ["linear"],
               ["get", activeBubble],
-              ...getLinearRamp([extent[0], extent[1]], [0, 8]),
+              ...getLinearRamp(
+                [extent[0], extent[1]],
+                [1, 8].map(adjustSizeFactor)
+              ),
             ],
             1,
           ],
@@ -145,7 +151,10 @@ const getBubbleLayerStyle = ({
               "interpolate",
               ["linear"],
               ["get", activeBubble],
-              ...getLinearRamp([extent[0], extent[1]], [6, 48]),
+              ...getLinearRamp(
+                [extent[0], extent[1]],
+                [6, 48].map(adjustSizeFactor)
+              ),
             ],
             6,
           ],
@@ -170,12 +179,12 @@ const getBubbleLayerStyle = ({
   ];
 };
 
-const getLayerStyle = (layerId, context) => {
+const getLayerStyle = (layerId, context, options) => {
   switch (layerId) {
     case "bubble":
-      return getBubbleLayerStyle(context);
+      return getBubbleLayerStyle(context, options);
     case "choropleth":
-      return getChoroplethLayerStyle(context);
+      return getChoroplethLayerStyle(context, options);
     default:
       throw new Error(`no getter for layerId: ${layerId}`);
   }
@@ -194,13 +203,14 @@ export default function useMapLayers() {
       shallow
     );
   const extents = useDataExtents();
-
+  const regions = useDashboardStore((state) => state.regions);
   return useMemo(() => {
     const metricConfig = metrics.find((m) => m.id === activeChoropleth);
     const scaleType = metricConfig?.scale || "continuous";
     const scaleData = extents?.[activeChoropleth]?.[2] || [];
     const scaleOptions = metricConfig?.scaleOptions || {};
     const scaleColors = metricConfig?.colors || DEFAULT_CHOROPLETH_COLORS;
+    const region = regions.find((r) => r.id === activeRegion);
     const context = {
       activeBubble,
       activeChoropleth,
@@ -208,10 +218,12 @@ export default function useMapLayers() {
       extents,
       colors: scaleColors,
       scales: getScales(scaleType, scaleData, scaleColors, scaleOptions),
+      region,
     };
-    const layers = REGION_LAYERS.map((layerId) =>
-      getLayerStyle(layerId, context)
-    ).filter(Boolean);
-    return layers.flat();
-  }, [activeBubble, activeChoropleth, activeRegion, extents, metrics]);
+    const layers = region?.layers
+      ?.map((layer) => getLayerStyle(layer.id, context, layer.options))
+      .filter(Boolean)
+      .flat();
+    return layers;
+  }, [activeBubble, activeChoropleth, activeRegion, extents, metrics, regions]);
 }


### PR DESCRIPTION
implementation of #59 

# Changes

- restructure region options to allow layer-level options
- add `scaleFactor` option to bubble layers that adjusts the sizing scale by a provided factor (default = 1, no change)

## before

![image](https://user-images.githubusercontent.com/21034/133502024-7ed42726-aaaf-4ae6-bfcd-eebc22061542.png)


## after

![image](https://user-images.githubusercontent.com/21034/133502071-28063b51-6034-4a65-a53b-a02be10044b4.png)
