### PR TITLE
fix(a11y): update tab order, ensure controls are accessible via keyboard

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -55,9 +55,8 @@ const App = ({ lang = "en", langDict, config }) => {
       </Header>
       {ready ? (
         <Body>
-          <Map>
-            <Legend />
-          </Map>
+          <Legend />
+          <Map></Map>
           <Panel id="DATA_OPTIONS" position="right" title={dataOptionsTitle}>
             <RegionSelect />
             <BubbleSelect />

--- a/src/Legend/Legend.js
+++ b/src/Legend/Legend.js
@@ -1,12 +1,5 @@
 import React, { useState } from "react";
-import {
-  Box,
-  Paper,
-  Typography,
-  withStyles,
-  useTheme,
-  Button,
-} from "@material-ui/core";
+import { Box, Paper, Typography, withStyles, Button } from "@material-ui/core";
 import useDashboardStore from "../Dashboard/hooks/useDashboardStore";
 import { useLang } from "../Language";
 import { animated, useSpring } from "react-spring";
@@ -100,6 +93,7 @@ const styles = (theme) => ({
     right: theme.spacing(2),
     zIndex: 10,
     width: 320,
+    pointerEvents: "all",
     [theme.breakpoints.down("xs")]: {
       top: "auto",
       bottom: 0,
@@ -127,8 +121,7 @@ const styles = (theme) => ({
 const AnimatedPaper = animated(Paper);
 
 const Legend = ({ classes, ...props }) => {
-  const theme = useTheme();
-  const { isMobile, isLargeDisplay } = useMediaQueries();
+  const { isMobile } = useMediaQueries();
 
   const setActivePanel = useDashboardStore((state) => state.setActivePanel);
   const [activeDateRange, setActiveDateRange] = useDashboardDateRange();
@@ -183,12 +176,7 @@ const Legend = ({ classes, ...props }) => {
   const flags = useDataFlags();
 
   // move legend if panel is open
-  const activePanel = useDashboardStore((state) => state.activePanel);
   const style = useSpring({
-    x:
-      activePanel && !isLargeDisplay
-        ? toggleBounds.width + theme.spacing(2)
-        : 0,
     y: isMobile && !showSummary ? toggleBounds.height : 0,
   });
   const handleToggle = useTogglePanel();

--- a/src/Map/Map.js
+++ b/src/Map/Map.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { withStyles } from "@material-ui/core";
+import { alpha, withStyles } from "@material-ui/core";
 import { Mapbox } from "@hyperobjekt/mapbox";
 import useMapLayers from "./hooks/useMapLayers";
 import useMapSources from "./hooks/useMapSources";
@@ -17,6 +17,19 @@ const styles = (theme) => ({
     width: "100%",
     height: "100%",
     zIndex: 1,
+
+    "& .HypMapbox-map:before": {
+      content: "''",
+      inset: 0,
+      position: "absolute",
+      border: `4px solid transparent`,
+      zIndex: 100,
+      transition: theme.transitions.create(["border-color"]),
+      pointerEvents: "none",
+    },
+    "& .HypMapbox-map:focus-within:before": {
+      borderColor: alpha(theme.palette.secondary.main, 0.5),
+    },
   },
   fitBoundsControl: {
     backgroundColor: theme.palette.background.paper,
@@ -78,6 +91,12 @@ const Map = ({ classes, className, children, ...props }) => {
       minZoom={7}
       interactiveLayerIds={interactiveLayers}
       className={clsx(classes.root, className)}
+      onLoad={(map) => {
+        // HACK: drop the tabindex attribute on the map wrapper (not needed, canvas has one)
+        map?.target
+          ?.getContainer()
+          ?.parentNode?.parentNode?.removeAttribute("tabindex");
+      }}
       {...props}
     >
       <Stack

--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -41,7 +41,7 @@ const styles = (theme) => ({
     minWidth: 320,
   },
   header: {
-    padding: theme.spacing(1, 1, 1, 3),
+    padding: theme.spacing(2, 3, 2, 3),
     borderBottom: `1px solid ${theme.palette.divider}`,
   },
   body: { padding: theme.spacing(3, 3) },
@@ -130,7 +130,11 @@ const Panel = ({
           className={clsx(classes.header)}
         >
           <Typography variant="h2">{title}</Typography>
-          <IconButton ref={buttonRef} onClick={() => setActivePanel(null)}>
+          <IconButton
+            ref={buttonRef}
+            size="small"
+            onClick={() => setActivePanel(null)}
+          >
             <CloseIcon />
           </IconButton>
         </Box>

--- a/src/theme.js
+++ b/src/theme.js
@@ -123,6 +123,13 @@ export default createTheme({
         color: HEADER_TEXT_COLOR,
       },
     },
+    MuiIconButton: {
+      root: {
+        "&:focus": {
+          ...FOCUS_STATE,
+        },
+      },
+    },
     MuiButton: {
       root: {
         textTransform: "none",
@@ -189,6 +196,15 @@ export default createTheme({
       },
     },
     MuiInputAdornment: {
+      root: {
+        "& .MuiIconButton-root": {
+          padding: "0.5rem",
+          "&:focus": {
+            // inset the focus state on input adornments so they dont overlap outer control focus
+            boxShadow: "inset 0 0 0 4px #fff, inset 0 0 0 6px #649BA6",
+          },
+        },
+      },
       positionStart: {
         marginLeft: "0.75rem",
         marginRight: 0,


### PR DESCRIPTION
# Changes

- move legend component so it follows the header in tab order
- remove tabindex on map container, as the canvas already has a tabindex to allow keyboard nav of map
- update focus styles of map and buttons