### PR TITLE
feat: add all data / selected location toggle to summary

### DIFF
--- a/src/Cards/components/EvictionSummaryCard.js
+++ b/src/Cards/components/EvictionSummaryCard.js
@@ -46,7 +46,9 @@ export const SummaryCard = ({
     ) : (
       <Tooltip
         title={
-          selectedLocations.length > 0 ? undefined : `No locations selected`
+          selectedLocations.length > 0
+            ? undefined
+            : `You have not selected any locations`
         }
         arrow
       >

--- a/src/Cards/components/EvictionSummaryCard.js
+++ b/src/Cards/components/EvictionSummaryCard.js
@@ -1,7 +1,15 @@
 import React from "react";
-import { Box, Typography } from "@material-ui/core";
+import {
+  Box,
+  Typography,
+  ButtonGroup,
+  Button,
+  Tooltip,
+} from "@material-ui/core";
 import { timeFormat } from "d3-time-format";
 import useSummaryData from "../../Data/useSummaryData";
+import { useLocationStore } from "../../Locations";
+import useSelectedLocationData from "../../Data/useSelectedLocationData";
 import {
   Card,
   StatsSummary,
@@ -27,14 +35,46 @@ export const SummaryCard = ({
   series,
   stats,
   children,
+  view,
+  handleToggleView,
+  selectedLocations,
   ...props
 }) => {
+  const selectedDataButtonLabel =
+    selectedLocations.length > 0 ? (
+      "Selected Locations"
+    ) : (
+      <Tooltip
+        title={
+          selectedLocations.length > 0 ? undefined : `No locations selected`
+        }
+        arrow
+      >
+        <span>Selected Locations</span>
+      </Tooltip>
+    );
+
   return (
     <Card title={title} {...props}>
-      <Box mt={-1} mb={2}>
-        <Typography gutterBottom variant="caption" color="textSecondary">
-          For All Counties
-        </Typography>
+      <Box mb={2}>
+        <ButtonGroup color="secondary" fullWidth>
+          <Button
+            variant={view === "all" && "contained"}
+            onClick={handleToggleView("all")}
+          >
+            All Data
+          </Button>
+          <Button
+            variant={view === "selected" && "contained"}
+            component={selectedLocations.length === 0 ? "div" : undefined} // use div when disabled so button emits events
+            disabled={selectedLocations.length === 0}
+            onClick={
+              selectedLocations.length > 0 && handleToggleView("selected")
+            }
+          >
+            {selectedDataButtonLabel}
+          </Button>
+        </ButtonGroup>
       </Box>
       <StatsSummary value={value} label={label} series={series} stats={stats}>
         {children}
@@ -48,6 +88,13 @@ export const SummaryCard = ({
  * trend line, and summary of stats.
  */
 const EvictionSummaryCard = (props) => {
+  //set state for displayed data
+  const [view, setView] = React.useState("all");
+
+  const handleToggleView = (view) => (e) => {
+    setView(view);
+  };
+
   // pull required data
   const { data: summary, status } = useSummaryData();
   const isReady = status === "success";
@@ -59,15 +106,53 @@ const EvictionSummaryCard = (props) => {
     date: timeFormat("%b %e, %Y")(parseDate(dateRange[1])),
     dateRange: formatDateString(...dateRange, { short: true }).join(" - "),
   });
-  // get primary metric
+
   const intFormatter = useFormatter("ef");
-  const value = isReady ? intFormatter(summary.ef) : "...";
-  // list of secondary stats
-  const stats = useSummaryStats(summary, SUMMARY_METRICS);
-  // use the 7 day moving average if more than 14 days
-  const series = useTrendSeries(summary?.series, dateRange, "ef");
+  const allStatsSeries = {
+    // get primary metric
+    value: isReady ? intFormatter(summary.ef) : "...",
+    // list of secondary stats
+    stats: useSummaryStats(summary, SUMMARY_METRICS),
+    //use the 7 day moving average if more than 14 days
+    series: useTrendSeries(summary?.series, dateRange, "ef"),
+  };
+
+  //get selected locations to set view state and to get data
+  const selectedLocations = useLocationStore((state) => state.locations);
+  //organize into object
+  const selectedStatsSeries = {
+    value: intFormatter(
+      useSelectedLocationData(selectedLocations, dateRange)?.selectedStatsRaw
+        ?.data?.ef
+    ),
+    stats: useSummaryStats(
+      useSelectedLocationData(selectedLocations, dateRange)?.selectedStatsRaw
+        ?.data,
+      SUMMARY_METRICS
+    ),
+    series: useSelectedLocationData(selectedLocations, dateRange).selectedSeries
+      ?.data?.series,
+  };
+
+  //if locations are unselected leaving none, switch view to all data
+  React.useEffect(() => {
+    if (view === "selected" && selectedLocations.length === 0) {
+      setView("all");
+    }
+  }, [selectedLocations, view]);
+
   return (
-    <SummaryCard {...{ title, label, value, stats, series }} {...props}>
+    <SummaryCard
+      {...{
+        title,
+        label,
+        view,
+        handleToggleView,
+        selectedLocations,
+      }}
+      {...(view === "all" ? allStatsSeries : selectedStatsSeries)}
+      {...props}
+    >
       <Typography variant="caption" color="textSecondary" component="em">
         {lastUpdated}
       </Typography>

--- a/src/Data/useSelectedLocationData.js
+++ b/src/Data/useSelectedLocationData.js
@@ -1,0 +1,56 @@
+import useLocationSeries from "../Locations/hooks/useLocationSeries";
+
+export default function useSelectedLocationData(selectedLocations, dateRange) {
+  const statsReducer = (prev, curr) => {
+    let result = { data: {} };
+    const locationKeys = Object.keys(prev.data);
+    locationKeys.forEach((locationKey) => {
+      if (
+        locationKey !== "id" &&
+        locationKey !== "series" &&
+        locationKey !== "efr"
+      ) {
+        result.data[locationKey] =
+          prev.data[locationKey] + curr.data[locationKey];
+      }
+    });
+    result.data["efr"] = result.data.rhh
+      ? 1000 * (result.data.ef / result.data.rhh)
+      : null;
+    return result;
+  };
+
+  const seriesReducer = (prev, curr) => {
+    let result = { data: { series: [] } };
+    result.data.series = prev.data.series.map((day, index) => {
+      const dayKeys = Object.keys(day);
+      let combinedDay = {};
+      dayKeys.forEach((dayKey) => {
+        if (dayKey !== "date" && dayKey !== "name" && dayKey !== "id") {
+          combinedDay[dayKey] = day[dayKey] + curr.data?.series[index][dayKey];
+        } else if (dayKey === "name") {
+          combinedDay[dayKey] = "selectedLocations";
+        } else {
+          combinedDay[dayKey] = day[dayKey];
+        }
+      });
+      return combinedDay;
+    });
+    return result;
+  };
+
+  const locationsData = useLocationSeries(selectedLocations, dateRange);
+  let isReady = 0;
+  locationsData.forEach((location) => {
+    if (location.status === "success") {
+      isReady++;
+    }
+  });
+  let selectedSeries;
+  let selectedStatsRaw;
+  if (isReady === locationsData.length && locationsData.length > 0) {
+    selectedSeries = locationsData.reduce(seriesReducer);
+    selectedStatsRaw = locationsData.reduce(statsReducer);
+  }
+  return { selectedSeries, selectedStatsRaw };
+}

--- a/src/Locations/hooks/useLocationSeries.js
+++ b/src/Locations/hooks/useLocationSeries.js
@@ -35,6 +35,7 @@ const fetchLocationSeries = (locationId, dateRange, region, feature) => {
           const totalFilings = locationSummary?.ef;
           const result = {
             id: series.location,
+            rhh: renterHouseholds,
             ef: totalFilings,
             tfa: locationSummary?.tfa,
             mfa: locationSummary?.mfa,

--- a/src/theme.js
+++ b/src/theme.js
@@ -189,6 +189,11 @@ export default createTheme({
         // turn on pointer events for disabled buttons
         "&.Mui-disabled": {
           pointerEvents: "auto",
+          "&:focus, &:hover": {
+            outline: "none",
+            boxShadow: "none",
+            borderColor: "rgba(0, 0, 0, 0.26)",
+          },
         },
       },
     },


### PR DESCRIPTION
# Changes

- Add hook to sum fields for selected locations
- Modify `EvictionSummaryCard` to track view state
- Add buttons to `EvictionSummaryCard` to toggle state, along with the necessary state tracking for disabling and displaying hint