### PR TITLE
Add events to tooltip

### DIFF
--- a/src/Dashboard/utils.js
+++ b/src/Dashboard/utils.js
@@ -43,7 +43,9 @@ export const formatDateRange = (
     month: options.short ? "short" : "long",
     day: "numeric",
     year:
-      startDate.getFullYear() === endDate.getFullYear() ? undefined : "numeric",
+      startDate?.getFullYear() === endDate?.getFullYear()
+        ? undefined
+        : "numeric",
   }).format(startDate);
   const endDateLabel = new Intl.DateTimeFormat("en-US", {
     month: options.short ? "short" : "long",

--- a/src/TimeSeries/components/TimeSeriesChart.js
+++ b/src/TimeSeries/components/TimeSeriesChart.js
@@ -13,8 +13,9 @@ import { curveMonotoneX } from "d3-shape";
 import { parseDate, Stat } from "../../Dashboard";
 import { Box, Paper, Typography } from "@material-ui/core";
 import { Stack } from "@hyperobjekt/material-ui-website";
-import { useTimeSeriesEventData } from "../../Data/useTimeSeriesEventData";
+import useTimeSeriesEventsInRange from "../hooks/useTimeSeriesEventsInRange";
 import TimeSeriesEvent from "./TimeSeriesEvent";
+import { isEventInRange } from "../utils";
 
 const TimeSeriesChart = ({
   lines,
@@ -29,7 +30,7 @@ const TimeSeriesChart = ({
   children,
   ...props
 }) => {
-  const { data: eventData } = useTimeSeriesEventData();
+  const eventData = useTimeSeriesEventsInRange();
   const customTheme = buildChartTheme({
     colors: lines.map((line) => line.color).reverse(),
   });
@@ -42,6 +43,17 @@ const TimeSeriesChart = ({
           }
         );
         const nearest = tooltipData?.nearestDatum?.datum;
+        const eventsInRange = eventData.reduce((eventsInRange, event) => {
+          if (
+            isEventInRange(
+              { start: new Date(nearest.date), end: new Date(nearest.date) },
+              event
+            )
+          ) {
+            eventsInRange.push(event);
+          }
+          return eventsInRange;
+        }, []);
         return (
           <Paper elevation={2}>
             <Box clone p={2} pb={0} bt={"none"}>
@@ -67,16 +79,18 @@ const TimeSeriesChart = ({
                 </Stat>
               ))}
             </Stack>
-            <Stack between="sm" direction="vertical" around="md">
-              {eventData?.map((event, i) => (
-                <TimeSeriesEvent
-                  key={event.name}
-                  radius={9}
-                  mt={i === 0 ? 0 : 2}
-                  {...event}
-                />
-              ))}
-            </Stack>
+            {eventsInRange.length > 0 && (
+              <Stack between="sm" direction="vertical" around="md">
+                {eventsInRange?.map((event, i) => (
+                  <TimeSeriesEvent
+                    key={event.name}
+                    radius={9}
+                    mt={i === 0 ? 0 : 2}
+                    {...event}
+                  />
+                ))}
+              </Stack>
+            )}
           </Paper>
         );
       };

--- a/src/TimeSeries/components/TimeSeriesChart.js
+++ b/src/TimeSeries/components/TimeSeriesChart.js
@@ -13,6 +13,8 @@ import { curveMonotoneX } from "d3-shape";
 import { parseDate, Stat } from "../../Dashboard";
 import { Box, Paper, Typography } from "@material-ui/core";
 import { Stack } from "@hyperobjekt/material-ui-website";
+import { useTimeSeriesEventData } from "../../Data/useTimeSeriesEventData";
+import TimeSeriesEvent from "./TimeSeriesEvent";
 
 const TimeSeriesChart = ({
   lines,
@@ -27,6 +29,7 @@ const TimeSeriesChart = ({
   children,
   ...props
 }) => {
+  const { data: eventData } = useTimeSeriesEventData();
   const customTheme = buildChartTheme({
     colors: lines.map((line) => line.color).reverse(),
   });
@@ -62,6 +65,16 @@ const TimeSeriesChart = ({
                     <circle r="4" cx="4" cy="4" fill={datum.color} />
                   </svg>
                 </Stat>
+              ))}
+            </Stack>
+            <Stack between="sm" direction="vertical" around="md">
+              {eventData?.map((event, i) => (
+                <TimeSeriesEvent
+                  key={event.name}
+                  radius={9}
+                  mt={i === 0 ? 0 : 2}
+                  {...event}
+                />
               ))}
             </Stack>
           </Paper>

--- a/src/TimeSeries/components/TimeSeriesEvent.js
+++ b/src/TimeSeries/components/TimeSeriesEvent.js
@@ -36,8 +36,16 @@ const TimeSeriesEvent = ({
 }) => {
   const dateLabel =
     start === end
-      ? formatDateString(start, { short: true })
-      : formatDateRange(...[start, end], { short: true }).join(" - ");
+      ? formatDateString(start?.toISOString().split("T")[0], { short: true })
+      : formatDateRange(
+          ...[
+            start?.toISOString().split("T")[0],
+            end?.toISOString().split("T")[0],
+          ],
+          {
+            short: true,
+          }
+        ).join(" - ");
   return (
     <Box
       mt={2}

--- a/src/TimeSeries/components/TimeSeriesEventsCard.js
+++ b/src/TimeSeries/components/TimeSeriesEventsCard.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { List } from "@material-ui/core";
-import { useTimeSeriesEventData } from "../../Data/useTimeSeriesEventData";
+import useTimeSeriesEventsInRange from "../hooks/useTimeSeriesEventsInRange";
 import { Card } from "../../Dashboard";
 import TimeSeriesEvent from "./TimeSeriesEvent";
 import { useLang } from "../../Language";
@@ -10,7 +10,7 @@ import { useLang } from "../../Language";
  */
 const TimeSeriesEventsCard = (props) => {
   const cardTitle = useLang("TITLE_EVENTS");
-  const eventsSeries = useTimeSeriesEventData().data;
+  const eventsSeries = useTimeSeriesEventsInRange();
   const glyphRadius = 9;
   return (
     <Card title={cardTitle} {...props}>

--- a/src/TimeSeries/hooks/useTimeSeriesEvents.js
+++ b/src/TimeSeries/hooks/useTimeSeriesEvents.js
@@ -1,0 +1,6 @@
+// TODO: pull in the time series events data and active range,
+//       and return the event data that falls within the range
+export default function useTimeSeriesEvents() {
+  // const { data } = useTimeSeriesEventData();
+  // const activeDateRange = useDashboardDateRange(); // probably named different
+}

--- a/src/TimeSeries/hooks/useTimeSeriesEvents.js
+++ b/src/TimeSeries/hooks/useTimeSeriesEvents.js
@@ -1,6 +1,0 @@
-// TODO: pull in the time series events data and active range,
-//       and return the event data that falls within the range
-export default function useTimeSeriesEvents() {
-  // const { data } = useTimeSeriesEventData();
-  // const activeDateRange = useDashboardDateRange(); // probably named different
-}

--- a/src/TimeSeries/hooks/useTimeSeriesEventsInRange.js
+++ b/src/TimeSeries/hooks/useTimeSeriesEventsInRange.js
@@ -1,0 +1,41 @@
+import { useTimeSeriesEventData } from "../../Data/useTimeSeriesEventData";
+import { isEventInRange } from "../utils";
+import { useDashboardDateRange } from "../../Dashboard";
+import { EVENT_COLORS } from "../../Dashboard/constants";
+
+export default function useTimeSeriesEventsInRange() {
+  const processedDates = (events, range) => {
+    const rangeDates = { start: new Date(range[0]), end: new Date(range[1]) };
+    const dates = events.reduce((dates, event) => {
+      const eventDates = {
+        start: new Date(event.start),
+        end: new Date(event.end),
+      };
+      if (isEventInRange(eventDates, rangeDates)) {
+        const start =
+          eventDates.start < rangeDates.start
+            ? rangeDates.start
+            : eventDates.start;
+        const end =
+          eventDates.end > rangeDates.end ? rangeDates.end : eventDates.end;
+        const color = event.color;
+        const id = event.id;
+        const name = event.name;
+        dates.push({ start, end, color, id, name });
+      }
+      return dates;
+    }, []);
+    return dates.map((date, index) => {
+      return {
+        ...date,
+        id: index + 1,
+        color: EVENT_COLORS[index % EVENT_COLORS.length],
+      };
+    });
+  };
+  const events = useTimeSeriesEventData().data;
+  const [activeDateRange] = useDashboardDateRange();
+  const data =
+    events && activeDateRange ? processedDates(events, activeDateRange) : [];
+  return data;
+}

--- a/src/TimeSeries/hooks/useTimeSeriesStore.js
+++ b/src/TimeSeries/hooks/useTimeSeriesStore.js
@@ -9,8 +9,6 @@ const useTimeSeriesStore = create((set) => ({
   setShowOverall: (showOverall) => set({ showOverall }),
   group: "avg7",
   setGroup: (group) => set({ group }),
-  hoveredEvent: "",
-  setHoveredEvent: (hoveredEvent) => set({ hoveredEvent }),
 }));
 
 export default useTimeSeriesStore;

--- a/src/TimeSeries/utils.js
+++ b/src/TimeSeries/utils.js
@@ -45,7 +45,7 @@ const weekTooltipFormat = (date) => {
 // month tooltip formatter
 const monthTooltipFormat = (includeYear) => {
   return includeYear ? timeFormat("%B %Y") : timeFormat("%B");
-}
+};
 
 /**
  * Returns a x tick formatter function for the provided group type
@@ -102,11 +102,11 @@ export function groupByWeek(data, metric = "ef") {
 /**
  * Accepts data by day and aggregates it by month
  */
- export function groupByMonth(data, metric = "ef") {
+export function groupByMonth(data, metric = "ef") {
   const grouped = {};
   data.forEach((d) => {
     //dates are converted to local time, add timezone offset to get UTC
-    const date = new Date(d.date+"T00:00:00");
+    const date = new Date(d.date + "T00:00:00");
     const month = date.getMonth();
     const year = date.getFullYear();
     const key = `${year}-${month + 1}`;
@@ -189,3 +189,75 @@ export const getDailyAverage = (metric, data, n = 7, offset = 0) => {
 
 export const getDaysBetween = (dateRange) =>
   timeDay.count(...dateRange.map(parseDate));
+
+/**
+ * Returns false if the eventDates date range falls outside
+ * of the rangeDates date range, or true if there is some overlap.
+ * @param {Date} eventDates
+ * @param {Date} rangeDates
+ * @returns
+ */
+export const isEventInRange = (eventDates, rangeDates) => {
+  return !(
+    (eventDates.start < rangeDates.start &&
+      eventDates.end < rangeDates.start) ||
+    (eventDates.start > rangeDates.end && eventDates.end > rangeDates.end)
+  );
+};
+
+export const doesEventOverlap = (eventDates, rangeDates) => {
+  if (!isEventInRange(eventDates, rangeDates)) return false;
+  const isEventPoint =
+    eventDates.start.toISOString() === eventDates.end.toISOString();
+  const isRangePoint =
+    rangeDates.start.toISOString() === rangeDates.end.toISOString();
+  // if neither event nor range is a point, they overlap
+  if (!isEventPoint && !isRangePoint) return true;
+  // thus, the range or event is a point, and if one of their starts or ends is the same, they overlap
+  return (
+    eventDates.start.toISOString() === rangeDates.start.toISOString() ||
+    eventDates.end.toISOString() === rangeDates.end.toISOString()
+  );
+};
+
+export const dateToString = (date) => {
+  return;
+};
+
+export const createTiers = (events) => {
+  return events.reduce((tiers, event) => {
+    let fits = null;
+    //if the levels array has already been populated
+    if (tiers.length > 0) {
+      //check every tier in the tiers array
+      for (let index = 0; index < tiers.length; index++) {
+        const tier = tiers[index];
+        let isOverlapping = false;
+        //check every range in the current tier
+        for (let i = 0; i < tier.length; i++) {
+          const range = tier[i];
+          if (doesEventOverlap(event, range)) {
+            isOverlapping = true;
+            break;
+          }
+          //if none of the ranges in the tier overlap with the event (or if the event is a single date), set the fits var to the index of the tier and stop checking
+        }
+        if (!isOverlapping) {
+          fits = index;
+          break;
+        }
+      }
+      //if the fits var was set to a level index, add the event to that level
+      if (fits !== null) {
+        tiers[fits].push(event);
+        //else make a new level with the event
+      } else {
+        tiers.push([event]);
+      }
+      //if the levels array is empty, create a new level with the event
+    } else {
+      tiers.push([event]);
+    }
+    return tiers;
+  }, []);
+};


### PR DESCRIPTION
# `useTimeSeriesEventsInRange`
- New hook to process events. Ingests all events and returns events in the current range.

# `TimeSeriesChart`
- Use `nearestTooltip` and `isEventInRange` to filter out events not encompassing the current hovered date.

# `Other Changes`
- In service of new hook, modify components using events to use the new return value.